### PR TITLE
Updated the portchannel testcases for validating on both legacy and unified design

### DIFF
--- a/tests/pc/test_lag_member.py
+++ b/tests/pc/test_lag_member.py
@@ -17,7 +17,8 @@ from tests.common.config_reload import config_reload
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology("t0")
+    pytest.mark.topology("t0"),
+    pytest.mark.parametrize("teamd_mode", ["unified", "multi_process"]),
 ]
 
 # TODO: Remove this once we no longer support Python 2
@@ -413,7 +414,8 @@ def check_arp(duthost, port_name, ip_address):
     return False
 
 
-def test_lag_member_status(duthost, most_common_port_speed, ptf_dut_setup_and_teardown):
+def test_lag_member_status(duthost, most_common_port_speed, ptf_dut_setup_and_teardown,
+                           teamd_mode, teamd_mode_config_unconfig):
     """
     Test ports' status of members in a lag
 
@@ -421,6 +423,7 @@ def test_lag_member_status(duthost, most_common_port_speed, ptf_dut_setup_and_te
         1.) Setup DUT and PTF
         2.) Get status of port channel new added and verify number of member and members' status is correct
     """
+    # Test state_db status for lag interfaces
     port_channel_status = duthost.get_port_channel_status(DUT_LAG_NAME)
     dut_hwsku = duthost.facts["hwsku"]
     number_of_lag_member = HWSKU_INTF_NUMBERS_DICT.get(dut_hwsku, DEAFULT_NUMBER_OF_MEMBER_IN_LAG)
@@ -462,7 +465,8 @@ def run_lag_member_traffic_test(duthost, dut_vlan, ptf_ports, ptfhost):
     ptf_runner(ptfhost, 'acstests', "lag_test.LagMemberTrafficTest", "/root/ptftests", params=params, is_python3=True)
 
 
-def test_lag_member_traffic(common_setup_teardown, duthost, ptf_dut_setup_and_teardown):
+def test_lag_member_traffic(common_setup_teardown, duthost, ptf_dut_setup_and_teardown,
+                            teamd_mode, teamd_mode_config_unconfig):
     """
     Test traffic about ports in a lag
 

--- a/tests/pc/test_lag_member_forwarding.py
+++ b/tests/pc/test_lag_member_forwarding.py
@@ -12,7 +12,8 @@ from tests.common.helpers.assertions import pytest_assert
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('any')
+    pytest.mark.topology('any'),
+    pytest.mark.parametrize("teamd_mode", ["unified", "multi_process"]),
 ]
 
 
@@ -69,7 +70,9 @@ def build_pkt(dest_mac, ip_addr, ttl):
     return pkt, exp_packet
 
 
-def test_lag_member_forwarding_packets(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo, ptfadapter):
+def test_lag_member_forwarding_packets(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
+                                       tbinfo, ptfadapter, teamd_mode, teamd_mode_config_unconfig):
+
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     lag_facts = duthost.lag_facts(host=duthost.hostname)['ansible_facts']['lag_facts']

--- a/tests/pc/test_po_cleanup.py
+++ b/tests/pc/test_po_cleanup.py
@@ -7,6 +7,7 @@ from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 pytestmark = [
     pytest.mark.disable_route_check,
     pytest.mark.topology('any'),
+    pytest.mark.parametrize("teamd_mode", ["unified", "multi_process"])
 ]
 
 LOG_EXPECT_PO_CLEANUP_RE = "cleanTeamProcesses: Sent SIGTERM to port channel.*{}.*"
@@ -44,11 +45,13 @@ def check_kernel_po_interface_cleaned(duthost, asic_index):
     return res == '0'
 
 
-def test_po_cleanup(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_asic_index, tbinfo):
+def test_po_cleanup(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_asic_index,
+                    tbinfo, teamd_mode, teamd_mode_config_unconfig):
     """
     test port channel are cleaned up correctly and teammgrd and teamsyncd process
     handle  SIGTERM gracefully
     """
+
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     logging.info("Disable swss/teamd Feature in all asics")
     # Following will call "sudo systemctl stop swss@0", same for swss@1 ..
@@ -58,11 +61,13 @@ def test_po_cleanup(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_as
         if not wait_until(10, 1, 0, check_kernel_po_interface_cleaned, duthost, asic_id):
             fail_msg = "PortChannel interface still exists in kernel"
             pytest.fail(fail_msg)
+
     # Restore config services
     config_reload(duthost, safe_reload=True, wait_for_bgp=True)
 
 
-def test_po_cleanup_after_reload(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo):
+def test_po_cleanup_after_reload(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
+                                 tbinfo, teamd_mode, teamd_mode_config_unconfig):
     """
     test port channel are cleaned up correctly after config reload, with system under stress.
     """
@@ -85,8 +90,11 @@ def test_po_cleanup_after_reload(duthosts, enum_rand_one_per_hwsku_frontend_host
     # Add start marker to the DUT syslog
     loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix='port_channel_cleanup')
     loganalyzer.expect_regex = []
-    for pc in port_channel_intfs:
-        loganalyzer.expect_regex.append(LOG_EXPECT_PO_CLEANUP_RE.format(pc))
+    if teamd_mode == "multi_process":
+        for pc in port_channel_intfs:
+            loganalyzer.expect_regex.append(LOG_EXPECT_PO_CLEANUP_RE.format(pc))
+    else:
+        loganalyzer.expect_regex.append(LOG_EXPECT_PO_CLEANUP_RE.format("teamd-unified"))
 
     try:
         # Make CPU high

--- a/tests/pc/test_po_update.py
+++ b/tests/pc/test_po_update.py
@@ -20,7 +20,8 @@ from tests.common.helpers.voq_helpers import verify_no_routes_from_nexthop
 
 pytestmark = [
     pytest.mark.topology('any'),
-    pytest.mark.device_type('vs')
+    pytest.mark.device_type('vs'),
+    pytest.mark.parametrize("teamd_mode", ["unified", "multi_process"])
 ]
 
 
@@ -81,7 +82,8 @@ def pc_active(asichost, portchannel):
     return asichost.interface_facts()['ansible_facts']['ansible_interface_facts'][portchannel]['active']
 
 
-def test_po_update(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, tbinfo):
+def test_po_update(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index,
+                   tbinfo, teamd_mode, teamd_mode_config_unconfig):
     """
     test port channel add/deletion as well ip address configuration
     """
@@ -191,7 +193,8 @@ def test_po_update_io_no_loss(
         enum_frontend_asic_index,
         tbinfo,
         ptfadapter,
-        reload_testbed_on_failed):
+        reload_testbed_on_failed, teamd_mode,
+        teamd_mode_config_unconfig):
     # GIVEN a lag topology, keep sending packets between 2 port channels
     # WHEN delete/add different members of a port channel
     # THEN no packets shall loss
@@ -503,7 +506,8 @@ def test_po_update_with_higher_lagids(
         enum_rand_one_per_hwsku_frontend_hostname,
         tbinfo,
         ptfadapter,
-        reload_testbed_on_failed, localhost):
+        reload_testbed_on_failed, localhost, teamd_mode,
+        teamd_mode_config_unconfig):
     """
     Test Port Channel Traffic with Higher LAG IDs:
 

--- a/tests/pc/test_po_voq.py
+++ b/tests/pc/test_po_voq.py
@@ -9,7 +9,8 @@ import logging
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('t2')
+    pytest.mark.topology('t2'),
+    pytest.mark.parametrize("teamd_mode", ["unified", "multi_process"])
 ]
 
 
@@ -103,7 +104,7 @@ def setup_teardown(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
         asic.config_portchannel_member(portchannel, portchannel_member, "add")
 
 
-def test_voq_po_update(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
+def test_voq_po_update(duthosts, enum_rand_one_per_hwsku_frontend_hostname, teamd_mode, teamd_mode_config_unconfig):
     """Test to verify when a LAG is added/deleted via CLI, it is synced across all DBs
 
     All DBs = local app db, chassis app db, local & remote asic db
@@ -142,7 +143,8 @@ def test_voq_po_update(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
             asic.config_portchannel(voq_lag.TMP_PC, "del")
 
 
-def test_voq_po_member_update(duthosts, enum_rand_one_per_hwsku_frontend_hostname, setup_teardown):
+def test_voq_po_member_update(duthosts, enum_rand_one_per_hwsku_frontend_hostname, setup_teardown,
+                              teamd_mode, teamd_mode_config_unconfig):
     """Test to verify when LAG members are added/deleted via CLI, it is synced across all DBs
 
     All DBs = local app db, chassis app db, local & remote asic db
@@ -184,7 +186,8 @@ def test_voq_po_member_update(duthosts, enum_rand_one_per_hwsku_frontend_hostnam
         asic.config_portchannel_member(voq_lag.TMP_PC, del_pc_member, "add")
 
 
-def test_voq_po_down_via_cli_update(duthosts, enum_rand_one_per_hwsku_frontend_hostname, setup_teardown):
+def test_voq_po_down_via_cli_update(duthosts, enum_rand_one_per_hwsku_frontend_hostname, setup_teardown,
+                                    teamd_mode, teamd_mode_config_unconfig):
     """Test to verify when a LAG goes down on an ASIC via CLI, it is synced across all DBs
 
     All DBs = local app db, chassis app db, local & remote asic db
@@ -228,7 +231,8 @@ def test_voq_po_down_via_cli_update(duthosts, enum_rand_one_per_hwsku_frontend_h
 
 @pytest.mark.parametrize("flap_method", ["local", "remote"])
 def test_voq_po_member_down_update(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                                   setup_teardown, fanouthosts, flap_method):
+                                   setup_teardown, fanouthosts, flap_method, teamd_mode,
+                                   teamd_mode_config_unconfig):
     """
     Test to verify when a LAG member goes down on an ASIC, it is synced across all DBs
 


### PR DESCRIPTION
testcase for enabling/disabling the mode for switching to/from legacy mode.

testcase scenario:

configuring the mode on redis-cli (CONFIG-DB).

TEAMD|GLOBAL
1.mode
2.multi-process

saving the config (config save -y)

reload the config (config reload -y)

Please find the attached test logs 

[sonic-mgmt-pc-logs.zip](https://github.com/user-attachments/files/21341714/sonic-mgmt-pc-logs.zip)
[pre-commit_logs.txt](https://github.com/user-attachments/files/21341716/pre-commit_logs.txt)

Latest_test_logs:

[sonic-mgmt_test_logs.zip](https://github.com/user-attachments/files/21428853/sonic-mgmt_test_logs.zip)

