### PR TITLE
Add guard check for get_supported_speeds method

### DIFF
--- a/tests/common/devices/fanout.py
+++ b/tests/common/devices/fanout.py
@@ -161,6 +161,9 @@ class FanoutHost(object):
         Returns:
             list: A list of supported speed strings or None
         """
+        if not hasattr(self.host, 'get_supported_speeds'):
+            logger.info("Host of type {} does not support 'get_supported_speeds'".format(type(self.host).__name__))
+            return None
         return self.host.get_supported_speeds(interface_name)
 
     def set_auto_negotiation_mode(self, interface_name, mode):


### PR DESCRIPTION
Added a hasattr() check to verify whether the host object supports 'get_supported_speeds' before calling it. This prevents potential AttributeError exceptions for host types that do not implement this method and logs an informational message instead.

Log : iface_namingmode.zip

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
